### PR TITLE
Add JSONL output format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,31 @@ pnpm install
 ## 使用方法
 
 ```bash
-# 基本的な使用方法
+# 基本的な使用方法（テーブル形式）
 pnpm start <銘柄コード>
 
 # 例：トヨタ自動車（7203）
 pnpm start 7203
+
+# JSONL形式で出力
+pnpm start 7203 --jsonl
 
 # 例：ソフトバンクグループ（9984）
 pnpm start 9984
 
 # または直接tsxで実行
 npx tsx src/index.ts 7203
+npx tsx src/index.ts 7203 --jsonl
 ```
 
+### 出力形式
+
+- **テーブル形式（デフォルト）**: 見やすい表形式で出力
+- **JSONL形式（`--jsonl`）**: 各行がJSONオブジェクトのJSONL形式で出力
+
 ## 出力例
+
+### テーブル形式
 
 ```
 === 7203.T - Today's 1-minute data (trading hours only) ===
@@ -45,6 +56,24 @@ Time		Open	High	Low	Close	Volume
 
 Total 326 records found (64 break-time records filtered out).
 ```
+
+### JSONL形式
+
+```jsonl
+{"symbol":"7203.T","timestamp":"2025-06-16T00:00:00.000Z","date":"2025-06-16","time":"09:00","open":2580.5,"high":2581.5,"low":2570,"close":2572.5,"volume":0}
+{"symbol":"7203.T","timestamp":"2025-06-16T00:01:00.000Z","date":"2025-06-16","time":"09:01","open":2573,"high":2577,"low":2569,"close":2570.5,"volume":243200}
+{"symbol":"7203.T","timestamp":"2025-06-16T00:02:00.000Z","date":"2025-06-16","time":"09:02","open":2570.5,"high":2577.5,"low":2570.5,"close":2575,"volume":224700}
+...
+```
+
+#### JSONLフィールド説明
+
+- `symbol`: 銘柄コード（Yahoo Finance形式）
+- `timestamp`: ISO 8601形式のタイムスタンプ（UTC）
+- `date`: 日付（YYYY-MM-DD）
+- `time`: 時刻（日本時間、HH:MM）
+- `open`, `high`, `low`, `close`: 株価（円）
+- `volume`: 出来高
 
 ## 対応銘柄
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,14 @@ interface StockData {
   volume: number;
 }
 
-async function fetchStockData(symbol: string): Promise<void> {
+async function fetchStockData(symbol: string, outputFormat: 'table' | 'jsonl' = 'table'): Promise<void> {
   try {
     // 東証銘柄の場合、.T を追加
     const yahooSymbol = symbol.includes('.') ? symbol : `${symbol}.T`;
     
-    console.log(`Fetching 1-minute data for ${yahooSymbol}...`);
+    if (outputFormat === 'table') {
+      console.log(`Fetching 1-minute data for ${yahooSymbol}...`);
+    }
     
     const today = new Date();
     const startOfDay = new Date(today.getFullYear(), today.getMonth(), today.getDate());
@@ -32,7 +34,9 @@ async function fetchStockData(symbol: string): Promise<void> {
     });
     
     if (!result.quotes || result.quotes.length === 0) {
-      console.log('No data found for today. Market might be closed or symbol invalid.');
+      if (outputFormat === 'table') {
+        console.log('No data found for today. Market might be closed or symbol invalid.');
+      }
       return;
     }
     
@@ -41,24 +45,47 @@ async function fetchStockData(symbol: string): Promise<void> {
       data.open !== null && data.high !== null && data.low !== null && data.close !== null
     );
     
-    console.log(`\n=== ${yahooSymbol} - Today's 1-minute data (trading hours only) ===`);
-    console.log('Time\t\tOpen\tHigh\tLow\tClose\tVolume');
-    console.log('─'.repeat(60));
-    
-    filteredQuotes.forEach((data) => {
-      const time = data.date.toLocaleTimeString('ja-JP', { 
-        hour: '2-digit', 
-        minute: '2-digit',
-        timeZone: 'Asia/Tokyo'
+    if (outputFormat === 'jsonl') {
+      // JSONL形式で出力
+      filteredQuotes.forEach((data) => {
+        const record = {
+          symbol: yahooSymbol,
+          timestamp: data.date.toISOString(),
+          date: data.date.toISOString().split('T')[0],
+          time: data.date.toLocaleTimeString('ja-JP', { 
+            hour: '2-digit', 
+            minute: '2-digit',
+            timeZone: 'Asia/Tokyo'
+          }),
+          open: Number(data.open!.toFixed(2)),
+          high: Number(data.high!.toFixed(2)),
+          low: Number(data.low!.toFixed(2)),
+          close: Number(data.close!.toFixed(2)),
+          volume: data.volume || 0
+        };
+        console.log(JSON.stringify(record));
+      });
+    } else {
+      // テーブル形式で出力
+      console.log(`\n=== ${yahooSymbol} - Today's 1-minute data (trading hours only) ===`);
+      console.log('Time\t\tOpen\tHigh\tLow\tClose\tVolume');
+      console.log('─'.repeat(60));
+      
+      filteredQuotes.forEach((data) => {
+        const time = data.date.toLocaleTimeString('ja-JP', { 
+          hour: '2-digit', 
+          minute: '2-digit',
+          timeZone: 'Asia/Tokyo'
+        });
+        
+        console.log(
+          `${time}\t${data.open!.toFixed(2)}\t${data.high!.toFixed(2)}\t` +
+          `${data.low!.toFixed(2)}\t${data.close!.toFixed(2)}\t${data.volume || 0}`
+        );
       });
       
-      console.log(
-        `${time}\t${data.open!.toFixed(2)}\t${data.high!.toFixed(2)}\t` +
-        `${data.low!.toFixed(2)}\t${data.close!.toFixed(2)}\t${data.volume || 0}`
-      );
-    });
-    
-    console.log(`\nTotal ${filteredQuotes.length} records found (${result.quotes.length - filteredQuotes.length} break-time records filtered out).`);
+      console.log(`\nTotal ${filteredQuotes.length} records found (${result.quotes.length - filteredQuotes.length} break-time records filtered out).`);
+    }
     
   } catch (error) {
     console.error('Error fetching stock data:', error);
@@ -71,8 +98,10 @@ program
   .description('Fetch 1-minute interval stock data for TSE stocks')
   .version('1.0.0')
   .argument('<symbol>', 'Stock symbol (e.g., 7203 for Toyota, 9984 for SoftBank)')
-  .action((symbol: string) => {
-    fetchStockData(symbol);
+  .option('-j, --jsonl', 'Output in JSONL format instead of table format')
+  .action((symbol: string, options: { jsonl?: boolean }) => {
+    const outputFormat = options.jsonl ? 'jsonl' : 'table';
+    fetchStockData(symbol, outputFormat);
   });
 
 program.parse(process.argv);


### PR DESCRIPTION
## Summary
- Add `--jsonl`/`-j` option to output stock data in JSONL format
- Maintain backward compatibility with table format as default
- Include comprehensive documentation and usage examples

## Features
- **JSONL Output**: Each line contains a complete JSON object with structured stock data
- **Rich Data Structure**: Includes symbol, timestamp, date, time, and OHLCV data
- **Machine Readable**: Perfect for data analysis tools and pipeline processing
- **Backward Compatible**: Table format remains the default output

## Usage Examples
```bash
# Table format (default)
pnpm start 7203

# JSONL format
pnpm start 7203 --jsonl

# Pipe to jq for processing
pnpm start 7203 --jsonl | jq '.close'
```

## JSON Structure
```json
{
  "symbol": "7203.T",
  "timestamp": "2025-06-16T00:00:00.000Z",
  "date": "2025-06-16",
  "time": "09:00",
  "open": 2580.5,
  "high": 2581.5,
  "low": 2570,
  "close": 2572.5,
  "volume": 0
}
```

## Test plan
- [x] Verify table format output remains unchanged
- [x] Test JSONL format with multiple stocks (7203, 9984)
- [x] Confirm JSON structure is valid and consistent
- [x] Verify help command shows new option
- [x] Test pipe compatibility with tools like jq and head

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a JSONL output format, allowing each stock data record to be output as a separate JSON object per line using the `--jsonl` flag.

- **Documentation**
  - Updated usage instructions and examples to clarify and demonstrate both table and JSONL output formats.
  - Added detailed explanations and examples for the new JSONL output option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->